### PR TITLE
implement more graceful error handling, fix issue #125 (#127)

### DIFF
--- a/examples/multi-bot/bot-facebook.js
+++ b/examples/multi-bot/bot-facebook.js
@@ -23,7 +23,15 @@ var controller = Botkit.facebookbot({
 
 var bot = controller.spawn();
 controller.hears('(.*)', 'message_received', function(bot, message) {
-  bot.reply(message, message.watsonData.output.text.join('\n'));
+  if (message.watsonError) {
+    console.log(message.watsonError);
+    bot.reply(message, message.watsonError.description || message.watsonError.error);
+  } else if (message.watsonData && 'output' in message.watsonData) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
+  } else {
+    console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  }
 });
 
 module.exports.controller = controller;

--- a/examples/multi-bot/bot-slack.js
+++ b/examples/multi-bot/bot-slack.js
@@ -22,7 +22,15 @@ var bot = controller.spawn({
 });
 
 controller.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
-  bot.reply(message, message.watsonData.output.text.join('\n'));
+  if (message.watsonError) {
+    console.log(message.watsonError);
+    bot.reply(message, message.watsonError.description || message.watsonError.error);
+  } else if (message.watsonData && 'output' in message.watsonData) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
+  } else {
+    console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  }
 });
 
 module.exports.controller = controller;

--- a/examples/multi-bot/bot-twilio.js
+++ b/examples/multi-bot/bot-twilio.js
@@ -27,7 +27,15 @@ var bot = controller.spawn({
   autojoin: true
 });
 controller.hears(['.*'], 'message_received', function(bot, message) {
-  bot.reply(message, message.watsonData.output.text.join('\n'));
+  if (message.watsonError) {
+    console.log(message.watsonError);
+    bot.reply(message, message.watsonError.description || message.watsonError.error);
+  } else if (message.watsonData && 'output' in message.watsonData) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
+  } else {
+    console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  }
 });
 
 module.exports.controller = controller;

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -36,9 +36,12 @@ slackController.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], f
   middleware.interpret(bot, message, function() {
     if (message.watsonError) {
       console.log(message.watsonError);
-      bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
-    } else {
+      bot.reply(message, message.watsonError.description || message.watsonError.error);
+    } else if (message.watsonData && 'output' in message.watsonData) {
       bot.reply(message, message.watsonData.output.text.join('\n'));
+    } else {
+      console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');
+      bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
     }
   });
 });


### PR DESCRIPTION
* add error checks in fb bot example

* Add error checks in slack bot example

* Add error checks to twilio bot example

* handle unknown/badly formed messages

* whoops typo fix

* whoops typo fix

* whoops typo fix

* whoops typo fix

* safer to check for error field first

* safer to check for error field first

* safer to check for error field first

* safer to check for error field first

* in case of error reply with actual error message

* in case of error reply with actual error message

* in case of error reply with actual error message

* check only for presence of output field

* check only for presence of output field

* check only for presence of output fields

* upd error message, check for output as field only